### PR TITLE
Avoid capture request accumulation

### DIFF
--- a/camera/camera_ndk.c
+++ b/camera/camera_ndk.c
@@ -29,25 +29,25 @@ ACameraDevice_stateCallbacks deviceStateCallbacks = {
 void session_on_ready(void *context, ACameraCaptureSession *session) {
     LOGI("session is ready. %p\n", session);
     pthread_mutex_lock(&cameraState.mutex);
-    cameraState.cameraReady = true;
-    cameraState.cameraActive = false;
+    cameraState.ready = true;
+    cameraState.active = false;
     pthread_mutex_unlock(&cameraState.mutex);
 }
 
 void session_on_active(void *context, ACameraCaptureSession *session) {
     LOGI("session is activated. %p\n", session);
     pthread_mutex_lock(&cameraState.mutex);
-    cameraState.cameraActive = true;
-    cameraState.cameraReady = false;
+    cameraState.active = true;
+    cameraState.ready = false;
     pthread_mutex_unlock(&cameraState.mutex);
 }
 
 void session_on_closed(void *context, ACameraCaptureSession *session) {
     LOGI("session is closed. %p\n", session);
     pthread_mutex_lock(&cameraState.mutex);
-    cameraState.cameraClosed = true;
-    cameraState.cameraActive = false;
-    cameraState.cameraReady = false;
+    cameraState.closed = true;
+    cameraState.active = false;
+    cameraState.ready = false;
     pthread_mutex_unlock(&cameraState.mutex);
 }
 
@@ -156,16 +156,16 @@ int openCamera(int index, int width, int height) {
 }
 
 int captureCamera() {
-    if (cameraState.cameraActive) {
+    if (cameraState.active) {
         LOGW("camera is already active.\n");
         return ACAMERA_OK;
     }
-    if (cameraState.cameraClosed) {
+    if (cameraState.closed) {
         LOGW("camera is already closed.\n");
         return ACAMERA_ERROR_INVALID_OPERATION;
     }
-    cameraState.cameraActive = false;
-    cameraState.cameraReady = false;
+    cameraState.active = false;
+    cameraState.ready = false;
     camera_status_t status = ACameraCaptureSession_capture(cameraCaptureSession, NULL, 1, &captureRequest, NULL);
     if(status != ACAMERA_OK) {
         LOGE("failed to capture image (reason: %d).\n", status);

--- a/camera/camera_ndk.c
+++ b/camera/camera_ndk.c
@@ -164,8 +164,6 @@ int captureCamera() {
         LOGW("camera is already closed.\n");
         return ACAMERA_ERROR_INVALID_OPERATION;
     }
-    LOGI("capture camera.\n");
-    // set cameraState to false
     cameraState.cameraActive = false;
     cameraState.cameraReady = false;
     camera_status_t status = ACameraCaptureSession_capture(cameraCaptureSession, NULL, 1, &captureRequest, NULL);

--- a/camera/camera_ndk.c
+++ b/camera/camera_ndk.c
@@ -154,16 +154,16 @@ int openCamera(int index, int width, int height) {
 
 int captureCamera() {
     pthread_mutex_lock(&cameraState.mutex);
-    do {
-        if (cameraState.status == CAMERA_ACTIVE) {
-            LOGW("camera is already active.\n");
-            break;
-        }
-        if (cameraState.status == CAMERA_CLOSED) {
-            LOGW("camera is already closed.\n");
-            break;
-        }
-    } while (0);
+    if (cameraState.status == CAMERA_ACTIVE) {
+        LOGW("camera is already active.\n");
+        pthread_mutex_unlock(&cameraState.mutex);
+        return ACAMERA_OK;
+    }
+    if (cameraState.status == CAMERA_CLOSED) {
+        LOGW("camera is already closed.\n");
+        pthread_mutex_unlock(&cameraState.mutex);
+        return ACAMERA_ERROR_INVALID_OPERATION;
+    }
     pthread_mutex_unlock(&cameraState.mutex);
     camera_status_t status = ACameraCaptureSession_capture(cameraCaptureSession, NULL, 1, &captureRequest, NULL);
     if(status != ACAMERA_OK) {

--- a/camera/camera_ndk.c
+++ b/camera/camera_ndk.c
@@ -156,16 +156,20 @@ int openCamera(int index, int width, int height) {
 }
 
 int captureCamera() {
+    pthread_mutex_lock(&cameraState.mutex);
     if (cameraState.active) {
         LOGW("camera is already active.\n");
+        pthread_mutex_unlock(&cameraState.mutex);
         return ACAMERA_OK;
     }
     if (cameraState.closed) {
         LOGW("camera is already closed.\n");
+        pthread_mutex_unlock(&cameraState.mutex);
         return ACAMERA_ERROR_INVALID_OPERATION;
     }
     cameraState.active = false;
     cameraState.ready = false;
+    pthread_mutex_unlock(&cameraState.mutex);
     camera_status_t status = ACameraCaptureSession_capture(cameraCaptureSession, NULL, 1, &captureRequest, NULL);
     if(status != ACAMERA_OK) {
         LOGE("failed to capture image (reason: %d).\n", status);

--- a/camera/camera_ndk.h
+++ b/camera/camera_ndk.h
@@ -22,10 +22,14 @@ typedef struct {
     pthread_mutex_t mutex;
 } GlobalImage;
 
+typedef enum {
+    CAMERA_CLOSED,
+    CAMERA_READY,
+    CAMERA_ACTIVE
+} CameraStatus;
+
 typedef struct {
-    bool active;
-    bool ready;
-    bool closed;
+    CameraStatus status;
     pthread_mutex_t mutex;
 } CameraState;
 

--- a/camera/camera_ndk.h
+++ b/camera/camera_ndk.h
@@ -23,9 +23,9 @@ typedef struct {
 } GlobalImage;
 
 typedef struct {
-    bool cameraActive;
-    bool cameraReady;
-    bool cameraClosed;
+    bool active;
+    bool ready;
+    bool closed;
     pthread_mutex_t mutex;
 } CameraState;
 

--- a/camera/camera_ndk.h
+++ b/camera/camera_ndk.h
@@ -24,8 +24,8 @@ typedef struct {
 
 typedef enum {
     CAMERA_CLOSED,
-    CAMERA_READY,
-    CAMERA_ACTIVE
+    CAMERA_ACTIVE,
+    CAMERA_READY
 } CameraStatus;
 
 typedef struct {

--- a/camera/camera_ndk.h
+++ b/camera/camera_ndk.h
@@ -22,7 +22,15 @@ typedef struct {
     pthread_mutex_t mutex;
 } GlobalImage;
 
+typedef struct {
+    bool cameraActive;
+    bool cameraReady;
+    bool cameraClosed;
+    pthread_mutex_t mutex;
+} CameraState;
+
 extern GlobalImage globalImage;
+extern CameraState cameraState;
 
 extern AImage *image;
 extern AImageReader *imageReader;


### PR DESCRIPTION
## Description

This PR adds state and setters for session callbacks and skips capture requests when the camera is actively processing to avoid a situation where the camera piles up with lingering capture requests.

I was able to verify through logcat that this allows the camera to flush requests before being queried again.

```
session is activated.
camera is already active.
camera is already active.
new image available.
session is ready.
ession is activated.
camera is already active.
camera is already active.
camera is already active.
new image available.
session is ready.
```

## Refs
- [ACameraCaptureSession_stateCallbacks](https://developer.android.com/ndk/reference/struct/a-camera-capture-session-state-callbacks)
- [aimagereader_acquirelatestimage](https://developer.android.com/ndk/reference/group/media#aimagereader_acquirelatestimage)