### PR TITLE
Use JPEG Pixel Format for Camera Capture

### DIFF
--- a/camera/camera_android.go
+++ b/camera/camera_android.go
@@ -58,7 +58,6 @@ type Options struct {
 
 type DroidCamera struct {
 	opts       Options
-	img        *image.YCbCr
 	logger     logging.Logger
 	cancelCtx  context.Context
 	cancelFunc context.CancelFunc
@@ -141,7 +140,6 @@ func New(ctx context.Context, name resource.Name, conf *Config, logger logging.L
 			Timestamp: conf.Timestamp,
 		},
 		logger: logger,
-		img:    image.NewYCbCr(image.Rect(0, 0, int(conf.Width), int(conf.Height)), image.YCbCrSubsampleRatio420),
 	}
 
 	ret := C.openCamera(C.int(conf.Index), C.int(conf.Width), C.int(conf.Height))

--- a/camera/camera_android.go
+++ b/camera/camera_android.go
@@ -85,6 +85,10 @@ func (c *DroidCamera) NextImage() (img image.Image, err error) {
 	var jpegPtr *C.uint8_t
 
 	C.AImage_getPlaneData(C.globalImage.image, 0, &jpegPtr, &jpegLen)
+	if jpegPtr == nil {
+		err = fmt.Errorf("camera: failed to get JPEG data")
+		return nil, err
+	}
 	jpegData := C.GoBytes(unsafe.Pointer(jpegPtr), jpegLen)
 
 	img, err = jpeg.Decode(bytes.NewReader(jpegData))

--- a/camera/camera_android.go
+++ b/camera/camera_android.go
@@ -5,9 +5,11 @@ package androidcamera
 // #include "camera_ndk.h"
 import "C"
 import (
+	"bytes"
 	"context"
 	"fmt"
 	"image"
+	"image/jpeg"
 	"unsafe"
 
 	"go.viam.com/rdk/components/camera"
@@ -80,23 +82,18 @@ func (c *DroidCamera) NextImage() (img image.Image, err error) {
 		return nil, err
 	}
 
-	var yStride C.int
-	var yLen, cbLen, crLen C.int
-	var yPtr, cbPtr, crPtr *C.uint8_t
+	var jpegLen C.int
+	var jpegPtr *C.uint8_t
 
-	C.AImage_getPlaneRowStride(C.globalImage.image, 0, &yStride)
-	C.AImage_getPlaneData(C.globalImage.image, 0, &yPtr, &yLen)
-	C.AImage_getPlaneData(C.globalImage.image, 1, &cbPtr, &cbLen)
-	C.AImage_getPlaneData(C.globalImage.image, 2, &crPtr, &crLen)
+	C.AImage_getPlaneData(C.globalImage.image, 0, &jpegPtr, &jpegLen)
+	jpegData := C.GoBytes(unsafe.Pointer(jpegPtr), jpegLen)
 
-	c.img.YStride = int(yStride)
-	c.img.CStride = int(yStride) / 2
+	img, err = jpeg.Decode(bytes.NewReader(jpegData))
+	if err != nil {
+		return nil, fmt.Errorf("camera: failed to decode JPEG: %v", err)
+	}
 
-	c.img.Y = C.GoBytes(unsafe.Pointer(yPtr), yLen)
-	c.img.Cb = C.GoBytes(unsafe.Pointer(cbPtr), cbLen)
-	c.img.Cr = C.GoBytes(unsafe.Pointer(crPtr), crLen)
-
-	img = rotateImage(c.img, c.opts.Rotate)
+	img = rotateImage(img, c.opts.Rotate)
 
 	return img, nil
 }

--- a/camera/camera_ndk.c
+++ b/camera/camera_ndk.c
@@ -109,7 +109,7 @@ int openCamera(int index, int width, int height) {
         return status;
     }
 
-    media_status_t mstatus = AImageReader_new(width, height, AIMAGE_FORMAT_YUV_420_888, 2, &imageReader);
+    media_status_t mstatus = AImageReader_new(width, height, AIMAGE_FORMAT_JPEG, 2, &imageReader);
     if(mstatus != AMEDIA_OK) {
         LOGE("failed to create image reader (reason: %d).\n", mstatus);
         return mstatus;


### PR DESCRIPTION
This is a simple PR that requests JPEG pixel format instead of YUV. This simplifies the go image fill and avoids issues with handling interleaved vs non-interleaved YUV when running on different devices.

Tested on an Android Tablet and Emulator running on Darwin.